### PR TITLE
fix: time consistency across the codebase

### DIFF
--- a/src/examples/full.ts
+++ b/src/examples/full.ts
@@ -37,14 +37,17 @@ const egsunit: EGSUnitInfo = {
     branch_industry: "Food"
 };
 
+// UTC date and time
+const currentDate = new Date().toISOString();
+
 // Sample Invoice
 const invoice = new ZATCASimplifiedTaxInvoice({
     props: {
         egs_info: egsunit,
         invoice_counter_number: 1,
         invoice_serial_number: "EGS1-886431145-1",
-        issue_date: "2022-03-13",
-        issue_time: "14:40:40",
+        issue_date: `${currentDate.split('T')[0]}`,
+        issue_time: `${currentDate.split('T')[1].slice(0, 8)}Z`,
         previous_invoice_hash: "NWZlY2ViNjZmZmM4NmYzOGQ5NTI3ODZjNmQ2OTZjNzljMmRiYzIzOWRkNGU5MWI0NjcyOWQ3M2EyN2ZiNTdlOQ==",
         line_items: [
             line_item,

--- a/src/zatca/qr/index.ts
+++ b/src/zatca/qr/index.ts
@@ -1,6 +1,3 @@
-import moment from "moment";
-
-
 import { XMLDocument } from "../../parser";
 import { getInvoiceHash } from "../signing";
 
@@ -38,8 +35,7 @@ export const generateQR = ({invoice_xml, digital_signature, public_key, certific
     // Detect if simplified invoice or not (not used currently assuming all simplified tax invoice)
     const invoice_type = invoice_xml.get("Invoice/cbc:InvoiceTypeCode")?.[0]["@_name"].toString();
 
-    const datetime = `${issue_date} ${issue_time}`;
-    const formatted_datetime = moment(datetime).format("YYYY-MM-DDTHH:mm:ss")+"Z";
+    const formatted_datetime = `${issue_date}T${issue_time}`
     
     const qr_tlv = TLV([
         seller_name,
@@ -74,8 +70,7 @@ export const generateQR = ({invoice_xml, digital_signature, public_key, certific
     const issue_date = invoice_xml.get("Invoice/cbc:IssueDate")?.[0];
     const issue_time = invoice_xml.get("Invoice/cbc:IssueTime")?.[0];
 
-    const datetime = `${issue_date} ${issue_time}`;
-    const formatted_datetime = moment(datetime).format("YYYY-MM-DDTHH:mm:ss")+"Z";
+    const formatted_datetime = `${issue_date}T${issue_time}`;
     
     const qr_tlv = TLV([
         seller_name,


### PR DESCRIPTION
When using UTC time-zone, time stamp must be suffixed with `Z`. Without it the time is assumed to be UTC+3.