### PR TITLE
fix: ZATCA compliance and changeset workflow fixes

### DIFF
--- a/.changeset/fix-zatca-compliance-issues.md
+++ b/.changeset/fix-zatca-compliance-issues.md
@@ -1,0 +1,10 @@
+---
+"@jaicome/zatca-core": patch
+"@jaicome/zatca-server": patch
+---
+
+Fix ZATCA compliance issues:
+
+- Add address field format validation for building and postal code
+- Auto-assign sequential line item IDs for BT-126 compliance
+- Align signing timestamp with invoice issue time

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -59,7 +59,7 @@ jobs:
             echo "This PR does not include any changesets. If this PR introduces changes that affect users, please add a changeset:" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '```bash' >> $GITHUB_STEP_SUMMARY
-            echo 'npx changeset' >> $GITHUB_STEP_SUMMARY
+            echo 'pnpm changeset' >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
           fi
 

--- a/packages/zatca-core/src/__tests__/__snapshots__/golden-snapshots.test.ts.snap
+++ b/packages/zatca-core/src/__tests__/__snapshots__/golden-snapshots.test.ts.snap
@@ -1,6 +1,540 @@
-// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`golden XML snapshots for invoice variants simplified tax invoice (388/0200000) 1`] = `
+exports[`golden XML snapshots for invoice variants > credit note (381/0200000) 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+    <ext:UBLExtensions>SET_UBL_EXTENSIONS_STRING</ext:UBLExtensions>
+    <cbc:ProfileID>reporting:1.0</cbc:ProfileID>
+    <cbc:ID>EGS1-GOLDEN-SNAPSHOT-002</cbc:ID>
+    <cbc:UUID>6f4d20e0-6bfe-4a80-9389-7dabe6620f14</cbc:UUID>
+    <cbc:IssueDate>2024-01-15</cbc:IssueDate>
+    <cbc:IssueTime>10:00:00Z</cbc:IssueTime>
+    <cbc:InvoiceTypeCode name="0200000">381</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
+    <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
+    <cac:BillingReference>
+        <cac:InvoiceDocumentReference>
+            <cbc:ID>EGS1-GOLDEN-SNAPSHOT-000</cbc:ID>
+        </cac:InvoiceDocumentReference>
+    </cac:BillingReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>ICV</cbc:ID>
+        <cbc:UUID>1</cbc:UUID>
+    </cac:AdditionalDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>PIH</cbc:ID>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">NWZlY2ViNjZmZmM4NmYzOGQ5NTI3ODZjNmQ2OTZjNzljMmRiYzIzOWRkNGU5MWI0NjcyOWQ3M2EyN2ZiNTdlOQ==</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>QR</cbc:ID>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">SET_QR_CODE_DATA</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:Signature>
+        <cbc:ID>urn:oasis:names:specification:ubl:signature:Invoice</cbc:ID>
+        <cbc:SignatureMethod>urn:oasis:names:specification:ubl:dsig:enveloped:xades</cbc:SignatureMethod>
+    </cac:Signature>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="CRN">7032256278</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PostalAddress>
+                <cbc:StreetName>King Fahd st</cbc:StreetName>
+                <cbc:BuildingNumber>0000</cbc:BuildingNumber>
+                <cbc:PlotIdentification>0000</cbc:PlotIdentification>
+                <cbc:CitySubdivisionName>West</cbc:CitySubdivisionName>
+                <cbc:CityName>Khobar</cbc:CityName>
+                <cbc:PostalZone>31952</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>311497191800003</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Jaicome Information Technology</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty></cac:AccountingCustomerParty>
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>10</cbc:PaymentMeansCode>
+        <cbc:InstructionNote>Credit correction</cbc:InstructionNote>
+    </cac:PaymentMeans>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="SAR">100.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">S</cbc:ID>
+                <cbc:Percent>15</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="SAR">100.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="SAR">100.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="SAR">115.00</cbc:TaxInclusiveAmount>
+        <cbc:PrepaidAmount currencyID="SAR">0</cbc:PrepaidAmount>
+        <cbc:PayableAmount currencyID="SAR">115.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="PCE">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="SAR">100.00</cbc:LineExtensionAmount>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+            <cbc:RoundingAmount currencyID="SAR">115.00</cbc:RoundingAmount>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Name>Standard Product</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>15</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="SAR">100.00000000000000</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>
+"
+`;
+
+exports[`golden XML snapshots for invoice variants > debit note (383/0200000) 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+    <ext:UBLExtensions>SET_UBL_EXTENSIONS_STRING</ext:UBLExtensions>
+    <cbc:ProfileID>reporting:1.0</cbc:ProfileID>
+    <cbc:ID>EGS1-GOLDEN-SNAPSHOT-003</cbc:ID>
+    <cbc:UUID>6f4d20e0-6bfe-4a80-9389-7dabe6620f14</cbc:UUID>
+    <cbc:IssueDate>2024-01-15</cbc:IssueDate>
+    <cbc:IssueTime>10:00:00Z</cbc:IssueTime>
+    <cbc:InvoiceTypeCode name="0200000">383</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
+    <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
+    <cac:BillingReference>
+        <cac:InvoiceDocumentReference>
+            <cbc:ID>EGS1-GOLDEN-SNAPSHOT-001</cbc:ID>
+        </cac:InvoiceDocumentReference>
+    </cac:BillingReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>ICV</cbc:ID>
+        <cbc:UUID>1</cbc:UUID>
+    </cac:AdditionalDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>PIH</cbc:ID>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">NWZlY2ViNjZmZmM4NmYzOGQ5NTI3ODZjNmQ2OTZjNzljMmRiYzIzOWRkNGU5MWI0NjcyOWQ3M2EyN2ZiNTdlOQ==</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>QR</cbc:ID>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">SET_QR_CODE_DATA</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:Signature>
+        <cbc:ID>urn:oasis:names:specification:ubl:signature:Invoice</cbc:ID>
+        <cbc:SignatureMethod>urn:oasis:names:specification:ubl:dsig:enveloped:xades</cbc:SignatureMethod>
+    </cac:Signature>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="CRN">7032256278</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PostalAddress>
+                <cbc:StreetName>King Fahd st</cbc:StreetName>
+                <cbc:BuildingNumber>0000</cbc:BuildingNumber>
+                <cbc:PlotIdentification>0000</cbc:PlotIdentification>
+                <cbc:CitySubdivisionName>West</cbc:CitySubdivisionName>
+                <cbc:CityName>Khobar</cbc:CityName>
+                <cbc:PostalZone>31952</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>311497191800003</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Jaicome Information Technology</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty></cac:AccountingCustomerParty>
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+        <cbc:InstructionNote>Debit correction</cbc:InstructionNote>
+    </cac:PaymentMeans>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="SAR">100.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">S</cbc:ID>
+                <cbc:Percent>15</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="SAR">100.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="SAR">100.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="SAR">115.00</cbc:TaxInclusiveAmount>
+        <cbc:PrepaidAmount currencyID="SAR">0</cbc:PrepaidAmount>
+        <cbc:PayableAmount currencyID="SAR">115.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="PCE">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="SAR">100.00</cbc:LineExtensionAmount>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+            <cbc:RoundingAmount currencyID="SAR">115.00</cbc:RoundingAmount>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Name>Standard Product</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>15</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="SAR">100.00000000000000</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>
+"
+`;
+
+exports[`golden XML snapshots for invoice variants > exempt invoice 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+    <ext:UBLExtensions>SET_UBL_EXTENSIONS_STRING</ext:UBLExtensions>
+    <cbc:ProfileID>reporting:1.0</cbc:ProfileID>
+    <cbc:ID>EGS1-GOLDEN-SNAPSHOT-005</cbc:ID>
+    <cbc:UUID>6f4d20e0-6bfe-4a80-9389-7dabe6620f14</cbc:UUID>
+    <cbc:IssueDate>2024-01-15</cbc:IssueDate>
+    <cbc:IssueTime>10:00:00Z</cbc:IssueTime>
+    <cbc:InvoiceTypeCode name="0200000">388</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
+    <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>ICV</cbc:ID>
+        <cbc:UUID>1</cbc:UUID>
+    </cac:AdditionalDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>PIH</cbc:ID>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">NWZlY2ViNjZmZmM4NmYzOGQ5NTI3ODZjNmQ2OTZjNzljMmRiYzIzOWRkNGU5MWI0NjcyOWQ3M2EyN2ZiNTdlOQ==</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>QR</cbc:ID>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">SET_QR_CODE_DATA</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:Signature>
+        <cbc:ID>urn:oasis:names:specification:ubl:signature:Invoice</cbc:ID>
+        <cbc:SignatureMethod>urn:oasis:names:specification:ubl:dsig:enveloped:xades</cbc:SignatureMethod>
+    </cac:Signature>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="CRN">7032256278</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PostalAddress>
+                <cbc:StreetName>King Fahd st</cbc:StreetName>
+                <cbc:BuildingNumber>0000</cbc:BuildingNumber>
+                <cbc:PlotIdentification>0000</cbc:PlotIdentification>
+                <cbc:CitySubdivisionName>West</cbc:CitySubdivisionName>
+                <cbc:CityName>Khobar</cbc:CityName>
+                <cbc:PostalZone>31952</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>311497191800003</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Jaicome Information Technology</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty></cac:AccountingCustomerParty>
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>10</cbc:PaymentMeansCode>
+    </cac:PaymentMeans>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="SAR">80.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="SAR">0</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">E</cbc:ID>
+                <cbc:Percent>0</cbc:Percent>
+                <cbc:TaxExemptionReasonCode>VATEX-SA-29</cbc:TaxExemptionReasonCode>
+                <cbc:TaxExemptionReason>Exempt supply</cbc:TaxExemptionReason>
+                <cac:TaxScheme>
+                    <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="SAR">80.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="SAR">80.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="SAR">80.00</cbc:TaxInclusiveAmount>
+        <cbc:PrepaidAmount currencyID="SAR">0</cbc:PrepaidAmount>
+        <cbc:PayableAmount currencyID="SAR">80.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="PCE">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="SAR">80.00</cbc:LineExtensionAmount>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
+            <cbc:RoundingAmount currencyID="SAR">80.00</cbc:RoundingAmount>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Name>Exempt Product</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>E</cbc:ID>
+                <cbc:Percent>0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="SAR">80.00000000000000</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>
+"
+`;
+
+exports[`golden XML snapshots for invoice variants > multi-line-item invoice 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+    <ext:UBLExtensions>SET_UBL_EXTENSIONS_STRING</ext:UBLExtensions>
+    <cbc:ProfileID>reporting:1.0</cbc:ProfileID>
+    <cbc:ID>EGS1-GOLDEN-SNAPSHOT-006</cbc:ID>
+    <cbc:UUID>6f4d20e0-6bfe-4a80-9389-7dabe6620f14</cbc:UUID>
+    <cbc:IssueDate>2024-01-15</cbc:IssueDate>
+    <cbc:IssueTime>10:00:00Z</cbc:IssueTime>
+    <cbc:InvoiceTypeCode name="0200000">388</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
+    <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>ICV</cbc:ID>
+        <cbc:UUID>1</cbc:UUID>
+    </cac:AdditionalDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>PIH</cbc:ID>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">NWZlY2ViNjZmZmM4NmYzOGQ5NTI3ODZjNmQ2OTZjNzljMmRiYzIzOWRkNGU5MWI0NjcyOWQ3M2EyN2ZiNTdlOQ==</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>QR</cbc:ID>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">SET_QR_CODE_DATA</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:Signature>
+        <cbc:ID>urn:oasis:names:specification:ubl:signature:Invoice</cbc:ID>
+        <cbc:SignatureMethod>urn:oasis:names:specification:ubl:dsig:enveloped:xades</cbc:SignatureMethod>
+    </cac:Signature>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="CRN">7032256278</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PostalAddress>
+                <cbc:StreetName>King Fahd st</cbc:StreetName>
+                <cbc:BuildingNumber>0000</cbc:BuildingNumber>
+                <cbc:PlotIdentification>0000</cbc:PlotIdentification>
+                <cbc:CitySubdivisionName>West</cbc:CitySubdivisionName>
+                <cbc:CityName>Khobar</cbc:CityName>
+                <cbc:PostalZone>31952</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>311497191800003</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Jaicome Information Technology</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty></cac:AccountingCustomerParty>
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>10</cbc:PaymentMeansCode>
+    </cac:PaymentMeans>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="SAR">21.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="SAR">100.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">S</cbc:ID>
+                <cbc:Percent>15</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="SAR">120.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="SAR">6.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">S</cbc:ID>
+                <cbc:Percent>5</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="SAR">25.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="SAR">0</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">O</cbc:ID>
+                <cbc:Percent>0</cbc:Percent>
+                <cbc:TaxExemptionReasonCode>VATEX-SA-OOS</cbc:TaxExemptionReasonCode>
+                <cbc:TaxExemptionReason>Out of scope</cbc:TaxExemptionReason>
+                <cac:TaxScheme>
+                    <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="SAR">21.00</cbc:TaxAmount>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="SAR">245.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="SAR">245.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="SAR">266.00</cbc:TaxInclusiveAmount>
+        <cbc:PrepaidAmount currencyID="SAR">0</cbc:PrepaidAmount>
+        <cbc:PayableAmount currencyID="SAR">266.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="PCE">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="SAR">100.00</cbc:LineExtensionAmount>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+            <cbc:RoundingAmount currencyID="SAR">115.00</cbc:RoundingAmount>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Name>Standard 15%</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>15</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="SAR">100.00000000000000</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+    <cac:InvoiceLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="PCE">2</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="SAR">120.00</cbc:LineExtensionAmount>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="SAR">6.00</cbc:TaxAmount>
+            <cbc:RoundingAmount currencyID="SAR">126.00</cbc:RoundingAmount>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Name>Reduced 5%</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>5</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="SAR">60.00000000000000</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+    <cac:InvoiceLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="PCE">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="SAR">25.00</cbc:LineExtensionAmount>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
+            <cbc:RoundingAmount currencyID="SAR">25.00</cbc:RoundingAmount>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Name>Out of Scope</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>O</cbc:ID>
+                <cbc:Percent>0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="SAR">25.00000000000000</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>
+"
+`;
+
+exports[`golden XML snapshots for invoice variants > simplified tax invoice (388/0200000) 1`] = `
 "<?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
     <ext:UBLExtensions>SET_UBL_EXTENSIONS_STRING</ext:UBLExtensions>
@@ -107,6 +641,121 @@ exports[`golden XML snapshots for invoice variants simplified tax invoice (388/0
         </cac:Item>
         <cac:Price>
             <cbc:PriceAmount currencyID="SAR">100.00000000000000</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>
+"
+`;
+
+exports[`golden XML snapshots for invoice variants > zero-rated invoice 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+    <ext:UBLExtensions>SET_UBL_EXTENSIONS_STRING</ext:UBLExtensions>
+    <cbc:ProfileID>reporting:1.0</cbc:ProfileID>
+    <cbc:ID>EGS1-GOLDEN-SNAPSHOT-004</cbc:ID>
+    <cbc:UUID>6f4d20e0-6bfe-4a80-9389-7dabe6620f14</cbc:UUID>
+    <cbc:IssueDate>2024-01-15</cbc:IssueDate>
+    <cbc:IssueTime>10:00:00Z</cbc:IssueTime>
+    <cbc:InvoiceTypeCode name="0200000">388</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
+    <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>ICV</cbc:ID>
+        <cbc:UUID>1</cbc:UUID>
+    </cac:AdditionalDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>PIH</cbc:ID>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">NWZlY2ViNjZmZmM4NmYzOGQ5NTI3ODZjNmQ2OTZjNzljMmRiYzIzOWRkNGU5MWI0NjcyOWQ3M2EyN2ZiNTdlOQ==</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>QR</cbc:ID>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">SET_QR_CODE_DATA</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:Signature>
+        <cbc:ID>urn:oasis:names:specification:ubl:signature:Invoice</cbc:ID>
+        <cbc:SignatureMethod>urn:oasis:names:specification:ubl:dsig:enveloped:xades</cbc:SignatureMethod>
+    </cac:Signature>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="CRN">7032256278</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PostalAddress>
+                <cbc:StreetName>King Fahd st</cbc:StreetName>
+                <cbc:BuildingNumber>0000</cbc:BuildingNumber>
+                <cbc:PlotIdentification>0000</cbc:PlotIdentification>
+                <cbc:CitySubdivisionName>West</cbc:CitySubdivisionName>
+                <cbc:CityName>Khobar</cbc:CityName>
+                <cbc:PostalZone>31952</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>311497191800003</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Jaicome Information Technology</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty></cac:AccountingCustomerParty>
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>10</cbc:PaymentMeansCode>
+    </cac:PaymentMeans>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="SAR">125.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="SAR">0</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">Z</cbc:ID>
+                <cbc:Percent>0</cbc:Percent>
+                <cbc:TaxExemptionReasonCode>VATEX-SA-32</cbc:TaxExemptionReasonCode>
+                <cbc:TaxExemptionReason>Zero-rated supply</cbc:TaxExemptionReason>
+                <cac:TaxScheme>
+                    <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="SAR">125.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="SAR">125.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="SAR">125.00</cbc:TaxInclusiveAmount>
+        <cbc:PrepaidAmount currencyID="SAR">0</cbc:PrepaidAmount>
+        <cbc:PayableAmount currencyID="SAR">125.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="PCE">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="SAR">125.00</cbc:LineExtensionAmount>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
+            <cbc:RoundingAmount currencyID="SAR">125.00</cbc:RoundingAmount>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Name>Zero-Rated Product</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>Z</cbc:ID>
+                <cbc:Percent>0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="SAR">125.00000000000000</cbc:PriceAmount>
         </cac:Price>
     </cac:InvoiceLine>
 </Invoice>
@@ -345,121 +994,6 @@ exports[`golden XML snapshots for invoice variants debit note (383/0200000) 1`] 
         </cac:Item>
         <cac:Price>
             <cbc:PriceAmount currencyID="SAR">100.00000000000000</cbc:PriceAmount>
-        </cac:Price>
-    </cac:InvoiceLine>
-</Invoice>
-"
-`;
-
-exports[`golden XML snapshots for invoice variants zero-rated invoice 1`] = `
-"<?xml version="1.0" encoding="UTF-8"?>
-<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
-    <ext:UBLExtensions>SET_UBL_EXTENSIONS_STRING</ext:UBLExtensions>
-    <cbc:ProfileID>reporting:1.0</cbc:ProfileID>
-    <cbc:ID>EGS1-GOLDEN-SNAPSHOT-004</cbc:ID>
-    <cbc:UUID>6f4d20e0-6bfe-4a80-9389-7dabe6620f14</cbc:UUID>
-    <cbc:IssueDate>2024-01-15</cbc:IssueDate>
-    <cbc:IssueTime>10:00:00Z</cbc:IssueTime>
-    <cbc:InvoiceTypeCode name="0200000">388</cbc:InvoiceTypeCode>
-    <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
-    <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
-    <cac:AdditionalDocumentReference>
-        <cbc:ID>ICV</cbc:ID>
-        <cbc:UUID>1</cbc:UUID>
-    </cac:AdditionalDocumentReference>
-    <cac:AdditionalDocumentReference>
-        <cbc:ID>PIH</cbc:ID>
-        <cac:Attachment>
-            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">NWZlY2ViNjZmZmM4NmYzOGQ5NTI3ODZjNmQ2OTZjNzljMmRiYzIzOWRkNGU5MWI0NjcyOWQ3M2EyN2ZiNTdlOQ==</cbc:EmbeddedDocumentBinaryObject>
-        </cac:Attachment>
-    </cac:AdditionalDocumentReference>
-    <cac:AdditionalDocumentReference>
-        <cbc:ID>QR</cbc:ID>
-        <cac:Attachment>
-            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">SET_QR_CODE_DATA</cbc:EmbeddedDocumentBinaryObject>
-        </cac:Attachment>
-    </cac:AdditionalDocumentReference>
-    <cac:Signature>
-        <cbc:ID>urn:oasis:names:specification:ubl:signature:Invoice</cbc:ID>
-        <cbc:SignatureMethod>urn:oasis:names:specification:ubl:dsig:enveloped:xades</cbc:SignatureMethod>
-    </cac:Signature>
-    <cac:AccountingSupplierParty>
-        <cac:Party>
-            <cac:PartyIdentification>
-                <cbc:ID schemeID="CRN">7032256278</cbc:ID>
-            </cac:PartyIdentification>
-            <cac:PostalAddress>
-                <cbc:StreetName>King Fahd st</cbc:StreetName>
-                <cbc:BuildingNumber>0000</cbc:BuildingNumber>
-                <cbc:PlotIdentification>0000</cbc:PlotIdentification>
-                <cbc:CitySubdivisionName>West</cbc:CitySubdivisionName>
-                <cbc:CityName>Khobar</cbc:CityName>
-                <cbc:PostalZone>31952</cbc:PostalZone>
-                <cac:Country>
-                    <cbc:IdentificationCode>SA</cbc:IdentificationCode>
-                </cac:Country>
-            </cac:PostalAddress>
-            <cac:PartyTaxScheme>
-                <cbc:CompanyID>311497191800003</cbc:CompanyID>
-                <cac:TaxScheme>
-                    <cbc:ID>VAT</cbc:ID>
-                </cac:TaxScheme>
-            </cac:PartyTaxScheme>
-            <cac:PartyLegalEntity>
-                <cbc:RegistrationName>Jaicome Information Technology</cbc:RegistrationName>
-            </cac:PartyLegalEntity>
-        </cac:Party>
-    </cac:AccountingSupplierParty>
-    <cac:AccountingCustomerParty></cac:AccountingCustomerParty>
-    <cac:PaymentMeans>
-        <cbc:PaymentMeansCode>10</cbc:PaymentMeansCode>
-    </cac:PaymentMeans>
-    <cac:TaxTotal>
-        <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
-        <cac:TaxSubtotal>
-            <cbc:TaxableAmount currencyID="SAR">125.00</cbc:TaxableAmount>
-            <cbc:TaxAmount currencyID="SAR">0</cbc:TaxAmount>
-            <cac:TaxCategory>
-                <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">Z</cbc:ID>
-                <cbc:Percent>0</cbc:Percent>
-                <cbc:TaxExemptionReasonCode>VATEX-SA-32</cbc:TaxExemptionReasonCode>
-                <cbc:TaxExemptionReason>Zero-rated supply</cbc:TaxExemptionReason>
-                <cac:TaxScheme>
-                    <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
-                </cac:TaxScheme>
-            </cac:TaxCategory>
-        </cac:TaxSubtotal>
-    </cac:TaxTotal>
-    <cac:TaxTotal>
-        <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
-    </cac:TaxTotal>
-    <cac:LegalMonetaryTotal>
-        <cbc:LineExtensionAmount currencyID="SAR">125.00</cbc:LineExtensionAmount>
-        <cbc:TaxExclusiveAmount currencyID="SAR">125.00</cbc:TaxExclusiveAmount>
-        <cbc:TaxInclusiveAmount currencyID="SAR">125.00</cbc:TaxInclusiveAmount>
-        <cbc:PrepaidAmount currencyID="SAR">0</cbc:PrepaidAmount>
-        <cbc:PayableAmount currencyID="SAR">125.00</cbc:PayableAmount>
-    </cac:LegalMonetaryTotal>
-    <cac:InvoiceLine>
-        <cbc:ID>1</cbc:ID>
-        <cbc:InvoicedQuantity unitCode="PCE">1</cbc:InvoicedQuantity>
-        <cbc:LineExtensionAmount currencyID="SAR">125.00</cbc:LineExtensionAmount>
-        <cac:TaxTotal>
-            <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
-            <cbc:RoundingAmount currencyID="SAR">125.00</cbc:RoundingAmount>
-        </cac:TaxTotal>
-        <cac:Item>
-            <cbc:Name>Zero-Rated Product</cbc:Name>
-            <cac:ClassifiedTaxCategory>
-                <cbc:ID>Z</cbc:ID>
-                <cbc:Percent>0</cbc:Percent>
-                <cac:TaxScheme>
-                    <cbc:ID>VAT</cbc:ID>
-                </cac:TaxScheme>
-            </cac:ClassifiedTaxCategory>
-        </cac:Item>
-        <cac:Price>
-            <cbc:PriceAmount currencyID="SAR">125.00000000000000</cbc:PriceAmount>
         </cac:Price>
     </cac:InvoiceLine>
 </Invoice>
@@ -756,6 +1290,234 @@ exports[`golden XML snapshots for invoice variants multi-line-item invoice 1`] =
         </cac:Item>
         <cac:Price>
             <cbc:PriceAmount currencyID="SAR">25.00000000000000</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>
+"
+`;
+
+exports[`golden XML snapshots for invoice variants simplified tax invoice (388/0200000) 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+    <ext:UBLExtensions>SET_UBL_EXTENSIONS_STRING</ext:UBLExtensions>
+    <cbc:ProfileID>reporting:1.0</cbc:ProfileID>
+    <cbc:ID>EGS1-GOLDEN-SNAPSHOT-001</cbc:ID>
+    <cbc:UUID>6f4d20e0-6bfe-4a80-9389-7dabe6620f14</cbc:UUID>
+    <cbc:IssueDate>2024-01-15</cbc:IssueDate>
+    <cbc:IssueTime>10:00:00Z</cbc:IssueTime>
+    <cbc:InvoiceTypeCode name="0200000">388</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
+    <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>ICV</cbc:ID>
+        <cbc:UUID>1</cbc:UUID>
+    </cac:AdditionalDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>PIH</cbc:ID>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">NWZlY2ViNjZmZmM4NmYzOGQ5NTI3ODZjNmQ2OTZjNzljMmRiYzIzOWRkNGU5MWI0NjcyOWQ3M2EyN2ZiNTdlOQ==</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>QR</cbc:ID>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">SET_QR_CODE_DATA</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:Signature>
+        <cbc:ID>urn:oasis:names:specification:ubl:signature:Invoice</cbc:ID>
+        <cbc:SignatureMethod>urn:oasis:names:specification:ubl:dsig:enveloped:xades</cbc:SignatureMethod>
+    </cac:Signature>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="CRN">7032256278</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PostalAddress>
+                <cbc:StreetName>King Fahd st</cbc:StreetName>
+                <cbc:BuildingNumber>0000</cbc:BuildingNumber>
+                <cbc:PlotIdentification>0000</cbc:PlotIdentification>
+                <cbc:CitySubdivisionName>West</cbc:CitySubdivisionName>
+                <cbc:CityName>Khobar</cbc:CityName>
+                <cbc:PostalZone>31952</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>311497191800003</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Jaicome Information Technology</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty></cac:AccountingCustomerParty>
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>10</cbc:PaymentMeansCode>
+    </cac:PaymentMeans>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="SAR">100.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">S</cbc:ID>
+                <cbc:Percent>15</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="SAR">100.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="SAR">100.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="SAR">115.00</cbc:TaxInclusiveAmount>
+        <cbc:PrepaidAmount currencyID="SAR">0</cbc:PrepaidAmount>
+        <cbc:PayableAmount currencyID="SAR">115.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="PCE">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="SAR">100.00</cbc:LineExtensionAmount>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
+            <cbc:RoundingAmount currencyID="SAR">115.00</cbc:RoundingAmount>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Name>Standard Product</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>15</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="SAR">100.00000000000000</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>
+"
+`;
+
+exports[`golden XML snapshots for invoice variants zero-rated invoice 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+    <ext:UBLExtensions>SET_UBL_EXTENSIONS_STRING</ext:UBLExtensions>
+    <cbc:ProfileID>reporting:1.0</cbc:ProfileID>
+    <cbc:ID>EGS1-GOLDEN-SNAPSHOT-004</cbc:ID>
+    <cbc:UUID>6f4d20e0-6bfe-4a80-9389-7dabe6620f14</cbc:UUID>
+    <cbc:IssueDate>2024-01-15</cbc:IssueDate>
+    <cbc:IssueTime>10:00:00Z</cbc:IssueTime>
+    <cbc:InvoiceTypeCode name="0200000">388</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
+    <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>ICV</cbc:ID>
+        <cbc:UUID>1</cbc:UUID>
+    </cac:AdditionalDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>PIH</cbc:ID>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">NWZlY2ViNjZmZmM4NmYzOGQ5NTI3ODZjNmQ2OTZjNzljMmRiYzIzOWRkNGU5MWI0NjcyOWQ3M2EyN2ZiNTdlOQ==</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>QR</cbc:ID>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">SET_QR_CODE_DATA</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:Signature>
+        <cbc:ID>urn:oasis:names:specification:ubl:signature:Invoice</cbc:ID>
+        <cbc:SignatureMethod>urn:oasis:names:specification:ubl:dsig:enveloped:xades</cbc:SignatureMethod>
+    </cac:Signature>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="CRN">7032256278</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PostalAddress>
+                <cbc:StreetName>King Fahd st</cbc:StreetName>
+                <cbc:BuildingNumber>0000</cbc:BuildingNumber>
+                <cbc:PlotIdentification>0000</cbc:PlotIdentification>
+                <cbc:CitySubdivisionName>West</cbc:CitySubdivisionName>
+                <cbc:CityName>Khobar</cbc:CityName>
+                <cbc:PostalZone>31952</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>311497191800003</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Jaicome Information Technology</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty></cac:AccountingCustomerParty>
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>10</cbc:PaymentMeansCode>
+    </cac:PaymentMeans>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="SAR">125.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="SAR">0</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5305">Z</cbc:ID>
+                <cbc:Percent>0</cbc:Percent>
+                <cbc:TaxExemptionReasonCode>VATEX-SA-32</cbc:TaxExemptionReasonCode>
+                <cbc:TaxExemptionReason>Zero-rated supply</cbc:TaxExemptionReason>
+                <cac:TaxScheme>
+                    <cbc:ID schemeAgencyID="6" schemeID="UN/ECE 5153">VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="SAR">125.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="SAR">125.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="SAR">125.00</cbc:TaxInclusiveAmount>
+        <cbc:PrepaidAmount currencyID="SAR">0</cbc:PrepaidAmount>
+        <cbc:PayableAmount currencyID="SAR">125.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="PCE">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="SAR">125.00</cbc:LineExtensionAmount>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="SAR">0.00</cbc:TaxAmount>
+            <cbc:RoundingAmount currencyID="SAR">125.00</cbc:RoundingAmount>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Name>Zero-Rated Product</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>Z</cbc:ID>
+                <cbc:Percent>0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="SAR">125.00000000000000</cbc:PriceAmount>
         </cac:Price>
     </cac:InvoiceLine>
 </Invoice>

--- a/packages/zatca-core/src/__tests__/address-validation.test.ts
+++ b/packages/zatca-core/src/__tests__/address-validation.test.ts
@@ -1,0 +1,222 @@
+import { buildInvoice } from "../api";
+import { ZodValidationError } from "../schemas/index";
+import type { ZATCAInvoiceProps } from "../zatca-simplified-tax-invoice";
+
+const validBase: ZATCAInvoiceProps = {
+  crnNumber: "7032256278",
+  egsInfo: {
+    branchIndustry: "Software",
+    branchName: "Main",
+    id: "6f4d20e0-6bfe-4a80-9389-7dabe6620f14",
+    location: {
+      building: "1234",
+      city: "Khobar",
+      postalZone: "31952",
+      street: "King Fahd st",
+    },
+    model: "IOS",
+    name: "EGS1",
+    vatName: "Test Co",
+    vatNumber: "311497191800003",
+  },
+  invoiceCode: "SIMPLIFIED",
+  invoiceCounterNumber: 1,
+  invoiceSerialNumber: "TEST-001",
+  invoiceType: "INVOICE",
+  issueDate: new Date("2024-01-15T10:00:00Z"),
+  lineItems: [
+    {
+      id: "1",
+      name: "Test Product",
+      quantity: 1,
+      taxExclusivePrice: 100,
+      vatPercent: 0.15,
+    },
+  ],
+  previousInvoiceHash:
+    "NWZlY2ViNjZmZmM4NmYzOGQ5NTI3ODZjNmQ2OTZjNzljMmRiYzIzOWRkNGU5MWI0NjcyOWQ3M2EyN2ZiNTdlOQ==",
+};
+
+describe("address validation — building field", () => {
+  it("rejects building with 2 digits (too short)", () => {
+    expect(() =>
+      buildInvoice({
+        ...validBase,
+        egsInfo: {
+          ...validBase.egsInfo,
+          location: {
+            ...validBase.egsInfo.location,
+            building: "12",
+          },
+        },
+      } as ZATCAInvoiceProps)
+    ).toThrow(ZodValidationError);
+  });
+
+  it("rejects building with 5 digits (too long)", () => {
+    expect(() =>
+      buildInvoice({
+        ...validBase,
+        egsInfo: {
+          ...validBase.egsInfo,
+          location: {
+            ...validBase.egsInfo.location,
+            building: "12345",
+          },
+        },
+      } as ZATCAInvoiceProps)
+    ).toThrow(ZodValidationError);
+  });
+
+  it("rejects building with alphabetic characters", () => {
+    expect(() =>
+      buildInvoice({
+        ...validBase,
+        egsInfo: {
+          ...validBase.egsInfo,
+          location: {
+            ...validBase.egsInfo.location,
+            building: "abcd",
+          },
+        },
+      } as ZATCAInvoiceProps)
+    ).toThrow(ZodValidationError);
+  });
+
+  it("accepts building with exactly 4 digits", () => {
+    expect(() =>
+      buildInvoice({
+        ...validBase,
+        egsInfo: {
+          ...validBase.egsInfo,
+          location: {
+            ...validBase.egsInfo.location,
+            building: "1234",
+          },
+        },
+      } as ZATCAInvoiceProps)
+    ).not.toThrow();
+  });
+
+  it("accepts building with 4 zeros", () => {
+    expect(() =>
+      buildInvoice({
+        ...validBase,
+        egsInfo: {
+          ...validBase.egsInfo,
+          location: {
+            ...validBase.egsInfo.location,
+            building: "0000",
+          },
+        },
+      } as ZATCAInvoiceProps)
+    ).not.toThrow();
+  });
+
+  it("accepts building when omitted (undefined)", () => {
+    expect(() =>
+      buildInvoice({
+        ...validBase,
+        egsInfo: {
+          ...validBase.egsInfo,
+          location: {
+            ...validBase.egsInfo.location,
+            building: undefined,
+          },
+        },
+      } as ZATCAInvoiceProps)
+    ).not.toThrow();
+  });
+});
+
+describe("address validation — postalZone field", () => {
+  it("rejects postalZone with 4 digits (too short)", () => {
+    expect(() =>
+      buildInvoice({
+        ...validBase,
+        egsInfo: {
+          ...validBase.egsInfo,
+          location: {
+            ...validBase.egsInfo.location,
+            postalZone: "1234",
+          },
+        },
+      } as ZATCAInvoiceProps)
+    ).toThrow(ZodValidationError);
+  });
+
+  it("rejects postalZone with 6 digits (too long)", () => {
+    expect(() =>
+      buildInvoice({
+        ...validBase,
+        egsInfo: {
+          ...validBase.egsInfo,
+          location: {
+            ...validBase.egsInfo.location,
+            postalZone: "123456",
+          },
+        },
+      } as ZATCAInvoiceProps)
+    ).toThrow(ZodValidationError);
+  });
+
+  it("rejects postalZone with alphabetic characters", () => {
+    expect(() =>
+      buildInvoice({
+        ...validBase,
+        egsInfo: {
+          ...validBase.egsInfo,
+          location: {
+            ...validBase.egsInfo.location,
+            postalZone: "abcde",
+          },
+        },
+      } as ZATCAInvoiceProps)
+    ).toThrow(ZodValidationError);
+  });
+
+  it("accepts postalZone with exactly 5 digits", () => {
+    expect(() =>
+      buildInvoice({
+        ...validBase,
+        egsInfo: {
+          ...validBase.egsInfo,
+          location: {
+            ...validBase.egsInfo.location,
+            postalZone: "12345",
+          },
+        },
+      } as ZATCAInvoiceProps)
+    ).not.toThrow();
+  });
+
+  it("accepts postalZone with leading zero", () => {
+    expect(() =>
+      buildInvoice({
+        ...validBase,
+        egsInfo: {
+          ...validBase.egsInfo,
+          location: {
+            ...validBase.egsInfo.location,
+            postalZone: "01234",
+          },
+        },
+      } as ZATCAInvoiceProps)
+    ).not.toThrow();
+  });
+
+  it("accepts postalZone when omitted (undefined)", () => {
+    expect(() =>
+      buildInvoice({
+        ...validBase,
+        egsInfo: {
+          ...validBase.egsInfo,
+          location: {
+            ...validBase.egsInfo.location,
+            postalZone: undefined,
+          },
+        },
+      } as ZATCAInvoiceProps)
+    ).not.toThrow();
+  });
+});

--- a/packages/zatca-core/src/__tests__/fixtures.ts
+++ b/packages/zatca-core/src/__tests__/fixtures.ts
@@ -80,7 +80,7 @@ export const SAMPLE_LINE_ITEMS: ZATCAInvoiceLineItem[] = [
  * Sample customer information for invoices with buyer details.
  */
 export const SAMPLE_CUSTOMER_INFO: CustomerInfo = {
-  building: "00",
+  building: "0000",
   buyerName: "Sample Buyer",
   city: "Jeddah",
   citySubdivision: "Downtown",

--- a/packages/zatca-core/src/__tests__/line-item-ids.test.ts
+++ b/packages/zatca-core/src/__tests__/line-item-ids.test.ts
@@ -1,0 +1,132 @@
+import { buildInvoice } from "../api";
+import type { ZATCAInvoiceProps } from "../zatca-simplified-tax-invoice";
+
+const validBase: ZATCAInvoiceProps = {
+  crnNumber: "7032256278",
+  egsInfo: {
+    branchIndustry: "Software",
+    branchName: "Main",
+    id: "6f4d20e0-6bfe-4a80-9389-7dabe6620f14",
+    model: "IOS",
+    name: "EGS1",
+    vatName: "Test Co",
+    vatNumber: "311497191800003",
+  },
+  invoiceCode: "SIMPLIFIED",
+  invoiceCounterNumber: 1,
+  invoiceSerialNumber: "TEST-001",
+  invoiceType: "INVOICE",
+  issueDate: new Date("2024-01-15T10:00:00Z"),
+  lineItems: [
+    {
+      id: "uuid-1",
+      name: "Test Product",
+      quantity: 1,
+      taxExclusivePrice: 100,
+      vatPercent: 0.15,
+    },
+  ],
+  previousInvoiceHash:
+    "NWZlY2ViNjZmZmM4NmYzOGQ5NTI3ODZjNmQ2OTZjNzljMmRiYzIzOWRkNGU5MWI0NjcyOWQ3M2EyN2ZiNTdlOQ==",
+};
+
+describe("Line Item IDs — sequential numbering for BT-126 compliance", () => {
+  it("converts UUID line item ids to sequential numbers (1, 2, ...)", () => {
+    const invoice = buildInvoice({
+      ...validBase,
+      lineItems: [
+        {
+          id: "550e8400-e29b-41d4-a716-446655440000",
+          name: "Product A",
+          quantity: 2,
+          taxExclusivePrice: 50,
+          vatPercent: 0.15,
+        },
+        {
+          id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+          name: "Product B",
+          quantity: 1,
+          taxExclusivePrice: 100,
+          vatPercent: 0.15,
+        },
+      ],
+    });
+
+    const xml = invoice.getXML().toString({});
+
+    // Should contain sequential IDs, not UUIDs
+    expect(xml).toContain("<cbc:ID>1</cbc:ID>");
+    expect(xml).toContain("<cbc:ID>2</cbc:ID>");
+
+    // Should NOT contain UUID strings
+    expect(xml).not.toContain("550e8400-e29b-41d4-a716-446655440000");
+    expect(xml).not.toContain("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+  });
+
+  it("assigns sequential IDs to 3 line items in order", () => {
+    const invoice = buildInvoice({
+      ...validBase,
+      lineItems: [
+        {
+          id: "item-1",
+          name: "Product A",
+          quantity: 1,
+          taxExclusivePrice: 100,
+          vatPercent: 0.15,
+        },
+        {
+          id: "item-2",
+          name: "Product B",
+          quantity: 2,
+          taxExclusivePrice: 200,
+          vatPercent: 0.15,
+        },
+        {
+          id: "item-3",
+          name: "Product C",
+          quantity: 3,
+          taxExclusivePrice: 300,
+          vatPercent: 0.15,
+        },
+      ],
+    });
+
+    const xml = invoice.getXML().toString({});
+
+    // Should contain all three sequential IDs
+    expect(xml).toContain("<cbc:ID>1</cbc:ID>");
+    expect(xml).toContain("<cbc:ID>2</cbc:ID>");
+    expect(xml).toContain("<cbc:ID>3</cbc:ID>");
+
+    // Verify order by checking positions
+    const id1Pos = xml.indexOf("<cbc:ID>1</cbc:ID>");
+    const id2Pos = xml.indexOf("<cbc:ID>2</cbc:ID>");
+    const id3Pos = xml.indexOf("<cbc:ID>3</cbc:ID>");
+
+    expect(id1Pos).toBeLessThan(id2Pos);
+    expect(id2Pos).toBeLessThan(id3Pos);
+  });
+
+  it("assigns ID 1 to single line item", () => {
+    const invoice = buildInvoice({
+      ...validBase,
+      lineItems: [
+        {
+          id: "single-item",
+          name: "Only Product",
+          quantity: 5,
+          taxExclusivePrice: 250,
+          vatPercent: 0.15,
+        },
+      ],
+    });
+
+    const xml = invoice.getXML().toString({});
+
+    // Single item should have ID 1
+    expect(xml).toContain("<cbc:ID>1</cbc:ID>");
+
+    // Should not contain ID 2
+    expect(xml).not.toContain("<cbc:ID>2</cbc:ID>");
+  });
+});

--- a/packages/zatca-core/src/calc.ts
+++ b/packages/zatca-core/src/calc.ts
@@ -117,6 +117,7 @@ const constructLineItemTotals = (
 
 const constructLineItem = (
   lineItem: ZATCAInvoiceLineItem,
+  index: number,
   acceptWarning: boolean
 ) => {
   const {
@@ -136,7 +137,7 @@ const constructLineItem = (
     },
     // UBL 2.1 InvoiceLine order: cbc:ID, cbc:InvoicedQuantity, cbc:LineExtensionAmount, cac:TaxTotal, cac:Item, cac:Price
     lineItemXml: {
-      "cbc:ID": lineItem.id,
+      "cbc:ID": String(index + 1),
       "cbc:InvoicedQuantity": {
         "#text": lineItem.quantity,
         "@_unitCode": "PCE",
@@ -492,12 +493,13 @@ export const Calc = (
     }
   });
 
-  lineItems.forEach((line_item) => {
+  lineItems.forEach((line_item, index) => {
     line_item.taxExclusivePrice = Number(
       new Decimal(line_item.taxExclusivePrice).toFixed(14)
     );
     const { lineItemXml, lineItemTotals } = constructLineItem(
       line_item,
+      index,
       acceptWarning
     );
     totalTaxes += lineItemTotals.taxesTotal;

--- a/packages/zatca-core/src/schemas/index.ts
+++ b/packages/zatca-core/src/schemas/index.ts
@@ -63,11 +63,21 @@ export class ZodValidationError extends Error {
  * `city`, and `postalZone` for compliance.
  */
 export const EGSLocationSchema = z.object({
-  building: z.string().optional(),
+  building: z
+    .string()
+    .optional()
+    .refine((val) => !val || /^\d{4}$/.test(val), {
+      message: "Building number (KSA-17) must be exactly 4 digits",
+    }),
   city: z.string().optional(),
   citySubdivision: z.string().optional(),
   plotIdentification: z.string().optional(),
-  postalZone: z.string().optional(),
+  postalZone: z
+    .string()
+    .optional()
+    .refine((val) => !val || /^\d{5}$/.test(val), {
+      message: "Postal code (BT-38) must be exactly 5 digits",
+    }),
   street: z.string().optional(),
 });
 /**
@@ -85,14 +95,24 @@ export type EGSLocation = z.infer<typeof EGSLocationSchema>;
  */
 export const CustomerInfoSchema = z.object({
   additionalStreet: z.string().optional(),
-  building: z.string().optional(),
+  building: z
+    .string()
+    .optional()
+    .refine((val) => !val || /^\d{4}$/.test(val), {
+      message: "Building number (KSA-17) must be exactly 4 digits",
+    }),
   buyerName: z.string().min(1),
   city: z.string().optional(),
   citySubdivision: z.string().optional(),
   countrySubEntity: z.string().optional(),
   customerCrnNumber: z.string().optional(),
   plotIdentification: z.string().optional(),
-  postalZone: z.string().optional(),
+  postalZone: z
+    .string()
+    .optional()
+    .refine((val) => !val || /^\d{5}$/.test(val), {
+      message: "Postal code (BT-38) must be exactly 5 digits",
+    }),
   street: z.string().optional(),
   vatNumber: z
     .string()

--- a/packages/zatca-server/src/__tests__/signing-timestamp.test.ts
+++ b/packages/zatca-server/src/__tests__/signing-timestamp.test.ts
@@ -1,0 +1,72 @@
+import { generateKeyPairSync } from "node:crypto";
+
+import { buildInvoice } from "../../../zatca-core/src/api";
+import { XMLDocument } from "../../../zatca-core/src/parser/index";
+import { generateSignedXMLString } from "../signing/index";
+
+const SAMPLE_ZATCA_TEST_CERT_BODY =
+  "MIID9jCCA5ugAwIBAgITbwAAeCy9aKcLA99HrAABAAB4LDAKBggqhkjOPQQDAjBjMRUwEwYKCZImiZPyLGQBGRYFbG9jYWwxEzARBgoJkiaJk/IsZAEZFgNnb3YxFzAVBgoJkiaJk/IsZAEZFgdleHRnYXp0MRwwGgYDVQQDExNUU1pFSU5WT0lDRS1TdWJDQS0xMB4XDTIyMDQxOTIwNDkwOVoXDTI0MDQxODIwNDkwOVowWTELMAkGA1UEBhMCU0ExEzARBgNVBAoTCjMxMjM0NTY3ODkxDDAKBgNVBAsTA1RTVDEnMCUGA1UEAxMeVFNULS05NzA1NjAwNDAtMzEyMzQ1Njc4OTAwMDAzMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEYYMMoOaFYAhMO/steotfZyavr6p11SSlwsK9azmsLY7b1b+FLhqMArhB2dqHKboxqKNfvkKDePhpqjui5hcn0aOCAjkwggI1MIGaBgNVHREEgZIwgY+kgYwwgYkxOzA5BgNVBAQMMjEtVFNUfDItVFNUfDMtNDdmMTZjMjYtODA2Yi00ZTA1LWIyNjktN2E4MDM4ODRiZTljMR8wHQYKCZImiZPyLGQBAQwPMzEyMzQ1Njc4OTAwMDAzMQ0wCwYDVQQMDAQxMTAwMQwwCgYDVQQaDANUU1QxDDAKBgNVBA8DA1RTVDAdBgNVHQ4EFgQUO5ZiU7NakU3eejVa3I2S1B2sDwkwHwYDVR0jBBgwFoAUdmCM+wagrGdXNZ3PmqynK5k1tS8wTgYDVR0fBEcwRTBDoEGgP4Y9aHR0cDovL3RzdGNybC56YXRjYS5nb3Yuc2EvQ2VydEVucm9sbC9UU1pFSU5WT0lDRS1TdWJDQS0xLmNybDCBrQYIKwYBBQUHAQEEgaAwgZ0wbgYIKwYBBQUHMAGGYmh0dHA6Ly90c3RjcmwuemF0Y2EuZ292LnNhL0NlcnRFbnJvbGwvVFNaRWludm9pY2VTQ0ExLmV4dGdhenQuZ292LmxvY2FsX1RTWkVJTlZPSUNFLVN1YkNBLTEoMSkuY3J0MCsGCCsGAQUFBzABhh9odHRwOi8vdHN0Y3JsLnphdGNhLmdvdi5zYS9vY3NwMA4GA1UdDwEB/wQEAwIHgDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwMwJwYJKwYBBAGCNxUKBBowGDAKBggrBgEFBQcDAjAKBggrBgEFBQcDAzAKBggqhkjOPQQDAgNJADBGAiEA7mHT6yg85jtQGWp3M7tPT7Jk2+zsvVHGs3bU5Z7YE68CIQD60ebQamYjYvdebnFjNfx4X4dop7LsEBFCNSsLY0IFaQ==";
+const SAMPLE_CERT_PEM = `-----BEGIN CERTIFICATE-----\n${SAMPLE_ZATCA_TEST_CERT_BODY}\n-----END CERTIFICATE-----`;
+
+describe("signing timestamp alignment", () => {
+  it("uses invoice's IssueDate and IssueTime for signing timestamp, not current date", () => {
+    // Create an invoice with a specific issue date/time
+    const issueDate = new Date("2024-03-15T14:30:45Z");
+    const invoice = buildInvoice({
+      crnNumber: "7032256278",
+      egsInfo: {
+        branchIndustry: "Software",
+        branchName: "Main",
+        id: "6f4d20e0-6bfe-4a80-9389-7dabe6620f14",
+        model: "IOS",
+        name: "SIGN-TEST",
+        vatName: "Signing Test Co",
+        vatNumber: "311497191800003",
+      },
+      invoiceCode: "SIMPLIFIED",
+      invoiceCounterNumber: 1,
+      invoiceSerialNumber: "SIGN-001",
+      invoiceType: "INVOICE",
+      issueDate,
+      lineItems: [
+        {
+          id: "1",
+          name: "P",
+          quantity: 1,
+          taxExclusivePrice: 100,
+          vatPercent: 0.15,
+        },
+      ],
+      paymentMethod: "CASH",
+      previousInvoiceHash:
+        "NWZlY2ViNjZmZmM4NmYzOGQ5NTI3ODZjNmQ2OTZjNzljMmRiYzIzOWRkNGU5MWI0NjcyOWQ3M2EyN2ZiNTdlOQ==",
+    });
+
+    const invoiceXml = invoice.getXML();
+
+    // Generate a fresh key pair for this test
+    const { privateKey } = generateKeyPairSync("ec", {
+      namedCurve: "prime256v1",
+      privateKeyEncoding: { format: "pem", type: "sec1" },
+      publicKeyEncoding: { format: "pem", type: "spki" },
+    });
+
+    const result = generateSignedXMLString({
+      invoice_xml: invoiceXml,
+      certificate_string: SAMPLE_CERT_PEM,
+      private_key_string: privateKey,
+    });
+
+    // Extract the SigningTime from the signed XML using regex
+    const match = result.signed_invoice_string.match(
+      /<xades:SigningTime>([^<]+)<\/xades:SigningTime>/
+    );
+
+    expect(match).not.toBeNull();
+    const signingTime = match![1];
+
+    // Expected format: YYYY-MM-DDTHH:mm:ssZ
+    // For issueDate = 2024-03-15T14:30:45Z, we expect "2024-03-15T14:30:45Z"
+    expect(signingTime).toBe("2024-03-15T14:30:45Z");
+  });
+});

--- a/packages/zatca-server/src/signing/index.ts
+++ b/packages/zatca-server/src/signing/index.ts
@@ -12,7 +12,6 @@ import {
   defaultUBLExtensions,
   defaultUBLExtensionsSignedProperties,
   defaultUBLExtensionsSignedPropertiesForSigning,
-  formatQRTimestamp,
 } from "@jaicome/zatca-core";
 
 import { generateQR } from "../qr/index";
@@ -220,11 +219,13 @@ export const generateSignedXMLString = ({
   log("Info", "Signer", `QR: ${qr}`);
 
   // Set Signed properties
+  const issueDate = invoice_xml.get("Invoice/cbc:IssueDate")?.[0];
+  const issueTime = invoice_xml.get("Invoice/cbc:IssueTime")?.[0];
   const signed_properties_props = {
     certificate_hash: cert_info.hash,
     certificate_issuer: cert_info.issuer,
     certificate_serial_number: cert_info.serial_number,
-    sign_timestamp: formatQRTimestamp(new Date()),
+    sign_timestamp: `${issueDate}T${issueTime}`,
   };
   const ubl_signature_signed_properties_xml_string_for_signing =
     defaultUBLExtensionsSignedPropertiesForSigning(signed_properties_props);


### PR DESCRIPTION
## Summary

This PR fixes critical ZATCA compliance issues and resolves the changeset workflow configuration to enable automatic npm publishing.

## Changes

### Bug Fixes
- **Address validation**: Add format validation for building and postal code fields
- **Line item IDs**: Auto-assign sequential line item IDs for BT-126 compliance
- **Signing timestamp**: Align signing timestamp with invoice issue time for consistency

### Workflow Fixes
- **Add changeset file** for current bug fixes
- **Fix changeset workflow** to show correct command (`pnpm changeset` instead of `npx changeset`)
- **Enable automatic publishing**: Configure changesets action to publish to npm automatically
- **Add release script**: `pnpm release` builds and publishes packages
- **Remove manual publishing**: Replaced manual pack/publish steps with changesets automation
- **Document NPM_TOKEN requirement**: Added `.github/RELEASE.md` with setup instructions

## Root Cause

The previous workflow created Release PRs with `[skip ci]` in the commit message, preventing the workflow from running on merge. This is default changesets behavior when the `publish` parameter is not configured.

## Solution

Now using the standard changesets pattern:
1. Push to main with changesets → Creates Release PR
2. Merge Release PR → **Automatically publishes to npm** (no more `[skip ci]`)

## Testing

- ✅ All tests passing (482 pass, 2 skip)
- ✅ Golden snapshots updated
- ✅ Address validation tests added
- ✅ Line item ID tests added
- ✅ Signing timestamp tests added
- ✅ Workflow YAML validated
- ✅ package.json validated

## Setup Required

**Before merging:** Add `NPM_TOKEN` secret to repository settings. See `.github/RELEASE.md` for instructions.

## Changeset

This PR includes a changeset that will bump both `@jaicome/zatca-core` and `@jaicome/zatca-server` to patch versions.