### PR TITLE
fix(ci): enable automatic npm publishing with changesets

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,0 +1,85 @@
+# Release Process
+
+This project uses [Changesets](https://github.com/changesets/changesets) for version management and automated npm publishing.
+
+## How It Works
+
+### 1. Adding Changes
+
+When you make changes that should be released:
+
+```bash
+pnpm changeset
+```
+
+This creates a changeset file describing your changes. Commit this file with your PR.
+
+### 2. Release PR
+
+When changesets are merged to `main`, the Release workflow automatically:
+
+- Creates/updates a "release: version packages" PR
+- Bumps package versions according to changesets
+- Updates CHANGELOG.md files
+
+### 3. Publishing
+
+When you merge the Release PR, the workflow automatically:
+
+- Builds all packages
+- Publishes to npm with provenance
+- Creates GitHub releases
+
+## Setup Requirements
+
+### NPM Token
+
+The workflow requires an `NPM_TOKEN` secret for publishing to npm.
+
+**Setting it up:**
+
+1. Generate an npm automation token:
+   - Go to https://www.npmjs.com/settings/{your-username}/tokens
+   - Click "Generate New Token" → "Automation"
+   - Copy the token
+
+2. Add it to GitHub secrets:
+   - Go to repository Settings → Secrets and variables → Actions
+   - Click "New repository secret"
+   - Name: `NPM_TOKEN`
+   - Value: (paste your token)
+
+**Important:** The token must have:
+
+- Publish access to `@jaicome/*` packages
+- 2FA on auth can be enabled, but 2FA on publish must be disabled
+
+## Manual Release
+
+To publish manually:
+
+```bash
+# Build packages
+bun run build
+
+# Publish to npm
+pnpm changeset publish
+```
+
+## Troubleshooting
+
+### "No changesets detected"
+
+Add a changeset file:
+
+```bash
+pnpm changeset
+```
+
+### Publish fails with auth error
+
+Check that `NPM_TOKEN` secret is set correctly in repository settings.
+
+### Version mismatch
+
+Ensure the Release PR was merged (not just closed) before expecting a publish.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,52 +52,15 @@ jobs:
 
       # Changesets action handles two scenarios:
       # 1. Changesets present → Create/update Release PR with version bumps
-      # 2. No changesets (Release PR was merged) → Prepare for publishing
-      - name: Version packages and create Release PR
+      # 2. No changesets (Release PR was merged) → Runs 'pnpm release' to build and publish
+      - name: Create Release PR or Publish to npm
         uses: changesets/action@v1
         id: changesets
         with:
           version: pnpm changeset version
+          publish: pnpm release
           title: "release: version packages"
           commit: "release: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Verify that package.json versions actually changed
-      # Prevents publishing on regular commits (only publish when Release PR merged)
-      - name: Detect version changes
-        id: version_check
-        if: steps.changesets.outputs.hasChangesets == 'false'
-        run: |
-          if git diff HEAD~1 HEAD --name-only | grep -q 'packages/.*/package.json'; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "✅ Package versions changed - will publish to npm" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "changed=false" >> $GITHUB_OUTPUT
-            echo "⏭️ No version changes - skipping publish" >> $GITHUB_STEP_SUMMARY
-          fi
-
-      # Publishing steps only execute when BOTH conditions are met:
-      # 1. No changesets present (Release PR was merged)
-      # 2. Package versions changed in this commit
-      - name: Pack @jaicome/zatca-core
-        if: steps.changesets.outputs.hasChangesets == 'false' && steps.version_check.outputs.changed == 'true'
-        run: pnpm --filter @jaicome/zatca-core pack --pack-destination /tmp/publish
-
-      - name: Pack @jaicome/zatca-server
-        if: steps.changesets.outputs.hasChangesets == 'false' && steps.version_check.outputs.changed == 'true'
-        run: pnpm --filter @jaicome/zatca-server pack --pack-destination /tmp/publish
-
-      - name: Publish @jaicome/zatca-core to npm
-        if: steps.changesets.outputs.hasChangesets == 'false' && steps.version_check.outputs.changed == 'true'
-        run: |
-          echo "📦 Publishing @jaicome/zatca-core..." >> $GITHUB_STEP_SUMMARY
-          npm publish /tmp/publish/jaicome-zatca-core-*.tgz --access public --provenance
-          echo "✅ Published @jaicome/zatca-core" >> $GITHUB_STEP_SUMMARY
-
-      - name: Publish @jaicome/zatca-server to npm
-        if: steps.changesets.outputs.hasChangesets == 'false' && steps.version_check.outputs.changed == 'true'
-        run: |
-          echo "📦 Publishing @jaicome/zatca-server..." >> $GITHUB_STEP_SUMMARY
-          npm publish /tmp/publish/jaicome-zatca-server-*.tgz --access public --provenance
-          echo "✅ Published @jaicome/zatca-server" >> $GITHUB_STEP_SUMMARY
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "check-boundaries": "bash scripts/check-boundaries.sh",
     "check": "ultracite check",
     "fix": "ultracite fix",
-    "prepare": "husky"
+    "prepare": "husky",
+    "release": "bun run build && pnpm changeset publish"
   },
   "dependencies": {
     "@fidm/x509": "^1.2.1",


### PR DESCRIPTION
## Problem

The release workflow was not publishing to npm after merging Release PRs. Root cause: changesets action adds `[skip ci]` to release commits when the `publish` parameter is not configured, preventing the workflow from running.

## Solution

Configure the changesets action to publish automatically using the standard pattern:

### Changes

1. **Add release script** (`pnpm release`): Builds and publishes packages
2. **Configure automatic publishing**: Added `publish: pnpm release` to changesets action
3. **Simplify workflow**: Removed manual pack/publish steps (now handled by changesets)
4. **Add NPM_TOKEN requirement**: Workflow now requires `NPM_TOKEN` secret
5. **Document setup**: Created `.github/RELEASE.md` with release process and NPM_TOKEN instructions

### How It Works Now

1. **Push to main with changesets** → Creates/updates Release PR
2. **Merge Release PR** → Automatically builds and publishes to npm (no more `[skip ci]`)

## Setup Required

⚠️ **Before merging:** Add `NPM_TOKEN` secret to repository settings.

See `.github/RELEASE.md` for detailed instructions on:
- Generating npm automation token
- Adding it to GitHub secrets  
- Token permissions required

## Testing

- ✅ Workflow YAML validated
- ✅ package.json validated
- ✅ Release script tested locally

## References

- [Changesets with Publishing](https://github.com/changesets/action#with-publishing)
- Follows official changesets action pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive release workflow documentation describing the Changesets-based release process, setup requirements, and troubleshooting guidance.

* **Chores**
  * Updated release automation to use Changesets' native publish functionality with improved npm authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->